### PR TITLE
Update unlisted-posts.php

### DIFF
--- a/unlisted-posts.php
+++ b/unlisted-posts.php
@@ -136,7 +136,7 @@ class Ray_Unlisted_Posts {
 	 * @return array
 	 */
 	public function the_posts( $posts ) {
-		if ( $posts[0] === $this->restore ) {
+		if ( count($posts) > 0 && $posts[0] === $this->restore ) {
 			$posts[0]->post_status = 'private';
 			$this->restore = null;
 		}


### PR DESCRIPTION
I'm not familiar with the code, but the check fixes the following warning:

Warning: Creating default object from empty value in /.../wp-content/plugins/unlisted-posts.php on line 140
